### PR TITLE
Update Dockerfile base image from snakemake v7.25.0 to v8.30.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-FROM snakemake/snakemake:v7.25.0
+FROM snakemake/snakemake:v8.30.0
 WORKDIR /workflows
-RUN apt update
-RUN apt install less
+RUN micromamba install -y -n base -c conda-forge less


### PR DESCRIPTION
The v7.25.0 image uses Debian Buster which is EOL and has broken apt repos. v8.30.0 uses Debian Bookworm (micromamba-based), so package installation switches from apt to micromamba. --use-singularity is still supported in v8 (aliased to --use-apptainer).